### PR TITLE
Refactoring: Add a 2nd argument for utils.clone() 

### DIFF
--- a/lib/gmplus/config.js
+++ b/lib/gmplus/config.js
@@ -3,5 +3,6 @@
 module.exports = {
   version: '3.exp',
   zoom: 8,
+  customMapOptions: ['id', 'lat', 'lng'],
   customMarkerOptions: ['lat', 'lng', 'move', 'bubble']
 };

--- a/lib/gmplus/map.js
+++ b/lib/gmplus/map.js
@@ -15,15 +15,10 @@ module.exports = function (global, that) {
 
     cb = cb || function () {};
 
-    var mapOptions = utils.clone(args); // To clone Array content
+    var mapOptions = utils.clone(args, config.customMapOptions); // To clone Array content
 
     mapOptions.zoom = args.zoom || config.zoom;
     mapOptions.center = new global.google.maps.LatLng(args.lat, args.lng);
-
-    // These are custom properties from GMP API that need to be unset.
-    mapOptions.id = undefined;
-    mapOptions.lat = undefined;
-    mapOptions.lng = undefined;
 
     that.id = args.id;
     that.options = args;

--- a/lib/gmplus/utils.js
+++ b/lib/gmplus/utils.js
@@ -1,12 +1,14 @@
 /*jslint node: true */
 "use strict";
-function clone(o) {
+function clone(o, exceptionKeys) {
   var out, v, key;
   out = Array.isArray(o) ? [] : {};
   for (key in o) {
     if (o.hasOwnProperty(key)) {
-      v = o[key];
-      out[key] = (typeof v === "object") ? clone(v) : v;
+      if (!exceptionKeys || (exceptionKeys && exceptionKeys.indexOf(key) === -1)) {
+        v = o[key];
+        out[key] = (typeof v === "object") ? clone(v) : v;
+      }
     }
   }
   return out;

--- a/test/unit/utils.Spec.js
+++ b/test/unit/utils.Spec.js
@@ -1,0 +1,33 @@
+
+describe('Given the Utils Class', function () {
+  describe('when calling clone()', function () {
+    it('should clone an object', function() {
+      var obj = {
+        property1: 'value1'
+      };
+
+      var utils = require('gmplus/utils');
+      var output = utils.clone(obj);
+      expect(output).to.eql(obj);
+      obj.property1 = 'value2';
+      expect(output.property1).to.eql('value1');
+    });
+
+    describe('with a an array of keys as second parameter', function () {
+
+      it('should not clone the exception keys', function() {
+        var obj = {
+          property1: 'value1',
+          property2: 'value2',
+          property3: 'value3'
+        };
+
+        var utils = require('gmplus/utils');
+        var output = utils.clone(obj, ['property2', 'property3']);
+        expect(output).to.eql({property1: 'value1'});
+      });
+
+    });
+
+  });
+});


### PR DESCRIPTION
so that you can 'exclude' some keys from being cloned. fixes: #116